### PR TITLE
Remove duplicate testimonial

### DIFF
--- a/testimonials.haml
+++ b/testimonials.haml
@@ -152,30 +152,6 @@
             %section{:class => 'row__colspaced'}
               %div{:class => 'colspan12-2 colspan8-2 colspan6-1 colspan2-1 as-grid with-gutter'}
                 %div{:class => 'col__module--img'}
-                  %i Mark Goodwin at Red Hat
-
-              %div{:class => 'colspan12-10 colspan8-6 colspan6-5 colspan2-1 as-grid with-gutter'}
-                %div{:class => 'features_left col__module--img'}
-                  %p
-                    "Here in Red Hat Global Support Services, we're actively moving our
-                    Red Hat Enterprise Linux customers to the next generation of open
-                    source performance monitoring and analysis tools. PCP is a perfect
-                    fit to replace the outgoing sysstat legacy tools, especially now
-                    PCP is fully supported in RHEL 6.6 / 7.x. Compelling features such
-                    as broad and easily extensible metrics coverage, fully distributed
-                    operation, uniform metric naming and meta-data, APIs with multiple
-                    language bindings, robust configurable logging services, and secure
-                    authenticated IPC protocols are essential in the modern enterprise
-                    environment. In our business of providing critical support services
-                    to our customers, the ability to capture archive logs on customer
-                    systems for off-site retrospective analysis is an especially
-                    important feature where PCP excells."
-
-        %div{:class => 'row-parent'}
-          %div{:class => 'row'}
-            %section{:class => 'row__colspaced'}
-              %div{:class => 'colspan12-2 colspan8-2 colspan6-1 colspan2-1 as-grid with-gutter'}
-                %div{:class => 'col__module--img'}
                   %i Ryan Doyle, Sysadmin
 
               %div{:class => 'colspan12-10 colspan8-6 colspan6-5 colspan2-1 as-grid with-gutter'}


### PR DESCRIPTION
It seems that Mark's Red Hat testimonial was added twice - once by @mbaldessari in 21c11176fd369e675900b4fda8b683b005e2073e, and then again by @natoscott in ec7e1789c9cfe6e9e662f3d7b9f640269cd32fe6.

I think it makes most sense to keep the second version, since it:
- includes the Red Hat logo; and
- includes a couple of minor grammatical improvments and spelling corrections (see diff below).

So this commit simply removes the first copy of Mark's testimonial.

The following diff shows the differences between the two testimonials. Note, the two testimonials were both normalised (in terms of spacing and line lengths) to make the diff meaningful.

``` diff
--- first.haml  2015-03-20 07:38:40.749479472 +1100
+++ second.haml 2015-03-20 07:38:49.482719516 +1100
@@ -3,15 +3,15 @@
 generation of open source performance monitoring and
 analysis tools.
 PCP is a perfect fit to replace the outgoing sysstat
-legacy tools, especially now PCP is fully supported
-in RHEL 6.6 / 7.x.
+legacy tools, especially now that PCP is fully supported
+in RHEL 6.6, RHEL 7 and onward.
 Compelling features such as broad and easily extensible
 metrics coverage, fully distributed operation, uniform
 metric naming and meta-data, APIs with multiple language
 bindings, robust configurable logging services, and secure
 authenticated IPC protocols are essential in the modern
 enterprise environment.
-In our business of providing critical support services to our customers,
+In our business of providing critical support services,
 the ability to capture archive logs on customer systems
 for off-site retrospective analysis is an especially
-important feature where PCP excells."
+important feature where PCP excels."
```
