### PR TITLE
Vagrant based site build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PCPGIT  := /home/michele/Devel/pcp
-DSTLOCAL := /srv/pcp.acksyn.org/
+PCPGIT  := /home/vagrant/pcp
+DSTLOCAL := /pcp-website/generated-pcp-website
 DSTREMOTE := webmichele2:/srv/pcp.acksyn.org/
 URL := http://pcp.acksyn.org
 -include ./localdefs
@@ -10,7 +10,7 @@ RSYNC := rsync -azvP --prune-empty-dirs --exclude '*.scss' --exclude '*.haml' \
 	--exclude '.gitignore' --exclude 'scripts' --exclude 'README.md' --exclude 'compass' \
 	--exclude '*.[1-9]' --exclude 'GNUmakefile' --exclude 'Check' --exclude 'stock-images' \
 	--exclude 'pcp-brand' --exclude 'NEWRELEASE' --exclude 'pcp.git' --exclude 'pcp-gui.git' \
-	--exclude 'srpm' --exclude 'buildbot'
+	--exclude 'srpm' --exclude 'buildbot' --exclude 'Vagrantfile' --exclude '.vagrant'
 
 all: clean import books man docs prep local
 

--- a/README
+++ b/README
@@ -1,5 +1,7 @@
 *** Website environment installation/configuration ***
 
+## Manual process for F20
+
 Instructions tested on an uptodate F20 installed with the minimal profile:
 1) Install the following packages:
 yum install -y git ruby rubygem-compass rubygem-haml lynx python rsync publican autoconf \
@@ -34,3 +36,13 @@ rsync the content to webserver
 
 You can run 'make check' to have linkchecker report on all the links, but it
 seems it requires the python-requests-2.2.0 package that is present in F21
+
+## Vagrant based site build
+
+With vagrant and virtualbox installed, run:
+
+`vagrant up`
+
+This will build the site in the `generated-pcp-website` directory
+
+rsync the content to webserver

--- a/README
+++ b/README
@@ -2,7 +2,7 @@
 
 Instructions tested on an uptodate F20 installed with the minimal profile:
 1) Install the following packages:
-yum install -y git ruby rubygem-compass rubygam-haml lynx python rsync publican autoconf \
+yum install -y git ruby rubygem-compass rubygem-haml lynx python rsync publican autoconf \
   avahi-devel bison cairo-devel cyrus-sasl-devel desktop-file-utils flex libibmad-devel \
   libibumad-devel libmicrohttpd-devel ncurses-devel nss-devel papi-devel perl-ExtUtils-MakeMaker \
   python-devel python3-devel qt-devel readline-devel rpm-devel systemd-devel systemtap-sdt-devel \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,46 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "bento/fedora-21"
+
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  config.vm.network "private_network", ip: "10.1.11.111"
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    vb.memory = "1024"
+  end
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/pcp-website"
+
+  config.vm.provision "shell", privileged: false,  inline: <<-SHELL
+    sudo yum install -y git ruby rubygem-compass rubygem-haml lynx python rsync publican autoconf \
+      avahi-devel bison cairo-devel cyrus-sasl-devel desktop-file-utils flex libibmad-devel \
+      libibumad-devel libmicrohttpd-devel ncurses-devel nss-devel papi-devel perl-ExtUtils-MakeMaker \
+      python-devel python3-devel qt-devel readline-devel rpm-devel systemd-devel systemtap-sdt-devel \
+      glibc-devel gcc gcc-c++ man2html vim linkchecker python-beautifulsoup4 rubygems python-requests
+
+	gem install sass -v 3.2.19
+	gem install sass-globbing
+
+	if [ -d "pcp" ]; then
+      cd pcp && git pull --rebase
+      cd ..
+	else
+      git clone https://github.com/performancecopilot/pcp.git
+	fi
+
+	if [ ! -L "/usr/share/publican/Common_Content/pcp-brand" ]; then
+      sudo ln -s /pcp-website/pcp-brand /usr/share/publican/Common_Content/
+	fi
+
+	cd pcp && ./configure --with-books --with-books-brand=pcp-brand && cd books && make
+	cd /pcp-website && make
+  SHELL
+end


### PR DESCRIPTION
Hi @natoscott !

I was investigating website changes the other day and wanted to build the site.  Not having a Fedora 20 machine around I decided to try to build the site using a vagrant based fedora machine (F21 seems to work).

With vagrant and virtualbox installed you can run:

`vagrant up`

From the root of the tree and the site is generated into a directory called `generated-pcp-website`

Hope that's helpful.
