### PR TITLE
Add device-mapper statistics PMDA idea

### DIFF
--- a/gsoc/2017/ideas.haml
+++ b/gsoc/2017/ideas.haml
@@ -526,4 +526,48 @@
               %a{:href => 'mailto:lberk@redhat.com'} Lukas Berk
             %br
 
+        %div{:class => 'colspan12-8 colspan8-5 colspan6-4 colspan2-2 as-grid with-gutter'}
+          %div{:class => 'col__module--img'}
+            %a{:name => 'dmstats'}
+            %h3 device-mapper statistics PMDA
+            %p
+              The device-mapper statistics framework (dmstats) provides flexible
+              IO statistics for device-mapper block devices, including logical
+              volumes, multipath and RAID devices, as well as thinly-provisioned
+              and cache volumes.
+
+              A command line tool,
+              %a{:href => 'https://www.mankier.com/8/dmstats'} dmstats,
+              allows administrators to configure and use the facility directly.
+
+              This project will use the dmstats API to allow dmstats performance
+              data to be made available to PCP users via a new PCP PMDA.
+
+              The primary API for dmstats is C but an experimental Python API
+              exists and may be suitable for prototyping.
+
+              The project will explore not only exporting simple counter and
+              metric values, but will also evaluate the feasibility of including
+              support for advanced features including dmstats latency and IO
+              distribution histograms.
+            %p
+              %strong Expected results:
+              A PCP PMDA for the dmstats subsystem will be designed, implemented,
+              tested and documented. The PMDA need not implement all the available
+              dmstats functionality immediately but it should be designed in such
+              a way as to permit future extension and enhancement.
+            %p
+              %strong Prerequisite knowledge:
+              C, Python (optional), some knowledge of logical volume management and
+              software defined storage is a bonus.
+            %p
+              %strong Skill level:
+              Intermediate-Advanced
+            %p
+              %strong Mentors:
+              %a{:href => 'mailto:bmr@redhat.com'} Bryn M. Reeves
+              ,
+              %a{:href => 'mailto:mgoodwin@redhat.com'} Mark Goodwin
+            %br
+
     = Haml::Engine.new(File.read("assets/haml-includes/footer.haml")).render


### PR DESCRIPTION
A quick PR to add the device-mapper statistics (dmstats) PMDA proposal to this year's GSOC ideas file.