### PR TITLE
Update an old url for HACKING file

### DIFF
--- a/community.haml
+++ b/community.haml
@@ -49,7 +49,7 @@
                     channel.
                   %p
                     Please refer to the
-                    %a{:href => "https://github.com/performancecopilot/pcp/blob/master/HACKING"} HACKING
+                    %a{:href => "https://github.com/performancecopilot/pcp/blob/master/HACKING.md"} HACKING
                     file in the PCP source tree for further information.
                     You are also encouraged to read the
                     %a{:href => "/faq.html"} FAQ


### PR DESCRIPTION
Update a file name in an old url, which was changed in https://github.com/performancecopilot/pcp/commit/a34c4d5cb25d0199f652f26a858ba069bac7381e