### PR TITLE
[docs] hyperlinks changes in the website

### DIFF
--- a/documentation.haml
+++ b/documentation.haml
@@ -67,25 +67,25 @@
                   %h3 Short Guides
                   %ul
                     %li
-                      %a{:href => '/docs/lab.pmchart.html'} Using Charts
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/UseCharts.html'} Using Charts
                     %li
-                      %a{:href => '/docs/lab.pmlogger.html'} Logging Basics
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/LoggingBasics.html'} Logging Basics
                     %li
-                      %a{:href => '/docs/lab.pmie.html'} Automated Reasoning Basics
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/AutomatedReasoningBasics.html'} Automated Reasoning Basics
                     %li
-                      %a{:href => '/docs/lab.pmieconf.html'} Configuring Automated Reasoning
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/ConfigureAutomatedReasoning.html'} Configuring Automated Reasoning
                     %li
-                      %a{:href => '/docs/lab.containers.html'} Analysis of Linux Containers
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/AnalyzeLinuxContainers.html'} Analysis of Linux Containers
                     %li
-                      %a{:href => '/docs/lab.secure.html'} Secure Connections
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/SecureConnections.html'} Secure Connections
                     %li
-                      %a{:href => '/docs/lab.secureclient.html'} Secure Client Connections
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/SecureClientConnections.html'} Secure Client Connections
                     %li
-                      %a{:href => '/docs/lab.auth.html'} Authenticated Connections
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/AuthenticatedConnections.html'} Authenticated Connections
                     %li
-                      %a{:href => '/docs/lab.importdata.html'} Importing data and creating PCP archives (C, Perl, Python)
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/ImportData.html'} Importing data and creating PCP archives (C, Perl, Python)
                     %li
-                      %a{:href => '/docs/lab.pmview.html'} Using 3D Views (experimental, source only)
+                      %a{:href => 'https://pcp.readthedocs.io/en/latest/QG/Use3DViews.html'} Using 3D Views (experimental, source only)
 
     %div{:class => 'hero'}
       %div{:class => 'colspan12-8 push12-2 colspan8-6 push8-1 colspan6-4 push6-1 colspan2-2'}


### PR DESCRIPTION
This PR changes the short guides documentation path to the new quick guides url. A click on the short guide name will take the user to the specific quick guide in pcp.readthedocs.io .