### PR TITLE
Remove reference to roadmap from Community page

### DIFF
--- a/community.haml
+++ b/community.haml
@@ -30,11 +30,6 @@
                     %a{:href => "https://github.com/performancecopilot"} organization
                     sub-projects.
                   %p
-                    You can follow work that others are actively engaged in
-                    using the interactive
-                    %a{:href => "https://github.com/performancecopilot/pcp/projects/1"} roadmap
-                    which also shows when upcoming releases are scheduled.
-                  %p
                     We are greatly interested in any efforts to expand the scope
                     of the available performance metrics with new agents, to port existing
                     performance tools to the PCP APIs, and to develop new clients to


### PR DESCRIPTION
### Context

While browsing the site I followed a link to the roadmap from the community page.  https://pcp.io/community.html

The page references a github project roadmap that no longer exists.  I can't find a replacement public roadmap.

### Change

- Remove the paragraph referencing the public roadmap from the community page.